### PR TITLE
Improve security features

### DIFF
--- a/lib/Helpers/BulkDownload.php
+++ b/lib/Helpers/BulkDownload.php
@@ -95,7 +95,7 @@ class BulkDownload {
 		$download_permitted = apply_filters('bdfgf_download_permission', $download_permitted, $form_id, $entry_ids );
 
 		if ( ! $download_permitted ) {
-			wp_die( esc_html( __( 'You don\'t have the permission to bulk download files for this entry', 'bulk-download-for-gravity-forms' ) ) );
+			wp_die( esc_html( __( 'You don\'t have the permission to bulk download files for this entry.', 'bulk-download-for-gravity-forms' ) ) );
 		}
 
 		// Increase some PHP limits.

--- a/lib/Helpers/BulkDownload.php
+++ b/lib/Helpers/BulkDownload.php
@@ -101,7 +101,16 @@ class BulkDownload {
 		// Increase some PHP limits.
 		add_filter( 'bdfgf_memory_limit', [ $this, 'set_memory_limit' ], 1 );
 		wp_raise_memory_limit( 'bdfgf' );
-		set_time_limit( apply_filters( 'bdfgf_max_execution_time', 120 ) );
+
+		/**
+		 * Filters the the max execution time.
+		 *
+		 * @param int $max_execution_time Max. execution time in seconds. Default: 120.
+		 *
+		 * @return int
+		 */
+		$max_execution_time = apply_filters( 'bdfgf_max_execution_time', 120 );
+		set_time_limit( $max_execution_time );
 
 		// Get the form object.
 		$form = GFAPI::get_form( $form_id );

--- a/lib/Helpers/BulkDownload.php
+++ b/lib/Helpers/BulkDownload.php
@@ -80,8 +80,21 @@ class BulkDownload {
 			wp_die( esc_html( __( 'The entry IDs to perform a bulk download for are missing.', 'bulk-download-for-gravity-forms' ) ) );
 		}
 
-		// Check permissions.
-		if ( ! GFCommon::current_user_can_any( 'gravityforms_view_entries' ) ) {
+		// Check permissions and if user is logged in.
+		$download_permitted = GFCommon::current_user_can_any( 'gravityforms_view_entries' );
+
+		/**
+		 * Filters the download permission.
+		 *
+		 * @param bool        $download_permitted  True if user is logged in and has gravityforms_view_entries permission.
+		 * @param int         $form_id             The GF form id.
+		 * @param array<int>  $entry_ids           The entry IDs of which all files will be added to the archive.
+		 *
+		 * @return bool
+		 */
+		$download_permitted = apply_filters('bdfgf_download_permission', $download_permitted, $form_id, $entry_ids );
+
+		if ( ! $download_permitted ) {
 			wp_die( esc_html( __( 'You don\'t have the permission to bulk download files for this entry', 'bulk-download-for-gravity-forms' ) ) );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -58,6 +58,10 @@ The plugin provides the filters `bdfgf_memory_limit` and `bdfgf_max_execution_ti
 
 You can find example usage of the [memory_limit](https://gist.github.com/vcat-support/f3b52c6f248e6a2b9301adfa845f206f) filter and the [max_execution_time](https://gist.github.com/vcat-support/09d72df61d084ab3250d491408c1e824) filter in the two linked GISTs.
 
+= Can I influence the permissions to download files in bulk?
+
+By default only logged in users with the `gravityforms_view_entries` capability are allowed to download files in bulk. You can use the `bdfgf_download_permission` filter to expand permission check.
+
 == Changelog ==
 
 = 3.0.0 =


### PR DESCRIPTION
This PR adds a filter to allow other plugins to influence the bulk download permission. This can be useful if the access should be managed per form.