### PR TITLE
Improve error checking

### DIFF
--- a/lib/Helpers/BulkDownload.php
+++ b/lib/Helpers/BulkDownload.php
@@ -204,6 +204,10 @@ class BulkDownload {
 		foreach ( $entry_ids as $entry_id ) {
 			$entry = GFAPI::get_entry( $entry_id );
 
+			if ( is_wp_error( $entry ) ) {
+				continue;
+			}
+
 			$uploaded_files[ $entry_id ] = [];
 			foreach ( $upload_fields as $upload_field ) {
 				// If the field is a multi file upload, add all files from the JSON object to the array of uploaded files.

--- a/lib/Helpers/BulkDownload.php
+++ b/lib/Helpers/BulkDownload.php
@@ -99,6 +99,10 @@ class BulkDownload {
 		// Get the form object.
 		$form = GFAPI::get_form( $form_id );
 
+		if ( empty( $form ) ) {
+			wp_die( esc_html__( 'Form not found.', 'bulk-download-for-gravity-forms' ) );
+		}
+
 		// Create a nice filename for the download.
 		$download_filename = $this->get_download_filename( $form, $entry_ids );
 

--- a/lib/Helpers/BulkDownload.php
+++ b/lib/Helpers/BulkDownload.php
@@ -112,6 +112,10 @@ class BulkDownload {
 		// Get upload files.
 		$uploaded_files = $this->get_uploaded_files( $upload_fields, $entry_ids );
 
+		if ( count( $uploaded_files ) === 0 ) {
+			wp_die( esc_html__( 'No files found.', 'bulk-download-for-gravity-forms' ) );
+		}
+
 		try {
 			// Create a temp file, so even if the process dies, the file might eventually get deleted.
 			$zip_filename = wp_tempnam( $download_filename . '.zip' );

--- a/lib/Helpers/BulkDownload.php
+++ b/lib/Helpers/BulkDownload.php
@@ -42,7 +42,13 @@ class BulkDownload {
 		}
 
 		$form_id   = (int) rgget( 'gf_form_id' );
-		$entry_ids = [ (int) rgget( 'gf_entry_id' ) ];
+		$entry_id  = absint( rgget( 'gf_entry_id' ) );
+
+		// Pass an empty array if entry id is not valid, to trigger the appropiate error message in bulk_download().
+		$entry_ids = array();
+		if ( $entry_id !== 0 ) {
+			$entry_ids[] = $entry_id;
+		}
 
 		$this->bulk_download( $form_id, $entry_ids );
 	}


### PR DESCRIPTION
This PR fixes a few possible fatal errors. For example:
- No files are found.
- Entries are no longer existent.
- The target form doesn't exist anymore.
- When the download url is being manipulated.